### PR TITLE
Math.round added bcs of incorrect work of isScrolledToBottom methods.

### DIFF
--- a/src/Scrollspy/RootEl.ts
+++ b/src/Scrollspy/RootEl.ts
@@ -17,7 +17,7 @@ export class RootEl extends Root {
   }
 
   get scrollTop() {
-    return this.el.scrollTop;
+    return Math.round(this.el.scrollTop);
   }
 
   get scrollHeight() {

--- a/src/Scrollspy/RootWindow.ts
+++ b/src/Scrollspy/RootWindow.ts
@@ -6,7 +6,7 @@ export class RootWindow extends Root {
   }
 
   get scrollTop() {
-    return document.documentElement.scrollTop;
+    return Math.round(document.documentElement.scrollTop);
   }
 
   get scrollHeight() {


### PR DESCRIPTION
It needed because scrollTop method works only with round values. 
https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop

"scrollTop can be set to any integer value"